### PR TITLE
add FA20 winners (up to All Hands 2)

### DIFF
--- a/src/components/winners.js
+++ b/src/components/winners.js
@@ -12,7 +12,7 @@ class Winners extends React.Component {
                 <div className="container">
                     <h4 className="service-des center-align wow bounceInRight" data-wow-duration=".6s"
                         data-wow-delay="0.4s">
-                        2020 Codewords Winners:
+                        {this.props.activity}
                     </h4>
                     {this.props.winners.map(row => {
                         return(<div className="row">

--- a/src/pages/winners.js
+++ b/src/pages/winners.js
@@ -6,7 +6,53 @@ import Matrix from "../components/matrix";
 import Winners from "../components/winners";
 import Footer from '../components/footer.js'
 // 2d Arr for winner list, each row takes 4 entries
-const amazingWinners = [
+const amazingWinnersFA20AllHands2 = [
+  [
+    {
+      name: 'Declan Sullivan',
+      img: 'https://tse.ucsd.edu/static/b76dd1c9eb47731c233e0308aaa941eb/04971/DeclanSullivan.jpg',
+      position: 'Project Manager'
+    },
+    {
+      name: 'Dhanush Nanjunda',
+      img: 'https://tse.ucsd.edu/static/8badbac7202ec344093488c0b16c5d7a/97641/DhanushReddy.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'Thai Gillespie',
+      img: 'https://tse.ucsd.edu/static/b73eddb438f370d3016325b693797c65/413c2/Anonymous.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'William Wu',
+      img: 'https://tse.ucsd.edu/static/b73eddb438f370d3016325b693797c65/413c2/Anonymous.jpg',
+      position: 'Developer'
+    }
+  ]
+];
+
+const amazingWinnersFA20AllHands1 = [
+  [
+
+    {
+      name: 'Amrit Singh',
+      img: 'https://tse.ucsd.edu/static/9cc8899f8de5afb3929d5204f0c1d7e6/0d026/AmritSingh.jpg',
+      position: 'Project Manager'
+    },
+    {
+      name: 'Mylinh Lac',
+      img: 'https://tse.ucsd.edu/static/c9c616626a92748c28e9330d2e12355e/d1027/MylinhLac.jpg',
+      position: 'Designer'
+    },
+    {
+      name: 'Nirmal Agnihotri',
+      img: 'https://tse.ucsd.edu/static/44edd4ff02e5aac2862a703246f3e0d8/c3133/NirmalAgnihotri.jpg',
+      position: 'Developer'
+    }
+  ]
+];
+
+const amazingWinnersSP20AllHands2 = [
   [
     {
       name: 'David Cruz',
@@ -32,13 +78,18 @@ const amazingWinners = [
 ];
 
 
+
+
+
 export default ({
     data
 }) => {
     return (
         <div className='body'>
             <Matrix/>
-            <Winners winners={amazingWinners}/>
+            <Winners winners={amazingWinnersFA20AllHands2} activity={"FA20 Many Truths One Lie Winners"}/>
+            <Winners winners={amazingWinnersFA20AllHands1} activity={"FA20 Family Feud Winners"}/>
+            <Winners winners={amazingWinnersSP20AllHands2} activity={"SP20 Codewords Winners"}/>
             <Footer/>
         </div>
     );


### PR DESCRIPTION
Resolves #27 and resolves #28 .

### Changes
- add winners of FA20 All Hands 1 and All Hands 2 to the Hall of Fame.

### TODOs
- ~~Add William Wu and Thai Gillespie to this PR (They aren't in the TritonSE org yet)~~
- We need to add support for <4 person teams (probably just centering). @ThomasLiARDJAVA maybe you can help a bit?
- I think we need to not hardcode links and query the db instead... but I don't have the time rn...
- We need to take pictures for everyone, but this is hard to resolve in COVID times...
- maybe extract constants into db? or at least another file, but this is minor refactor. may or may not be wrong here

### Picture of Change

| pic of new change |
| --- |
| ![Screenshot from 2020-11-13 21-02-26](https://user-images.githubusercontent.com/35469114/99140175-2b155b80-25f4-11eb-9418-1a3a9feb8d56.png) |
