### PR TITLE
Add FA20 Social Event and Design Workshop winners

### DIFF
--- a/src/pages/winners.js
+++ b/src/pages/winners.js
@@ -6,6 +6,63 @@ import Matrix from "../components/matrix";
 import Winners from "../components/winners";
 import Footer from '../components/footer.js'
 // 2d Arr for winner list, each row takes 4 entries
+const amazingWinnersFA20SocialEvent = [
+  [
+    {
+      name: 'Justin Yao Du',
+      img: 'https://tse.ucsd.edu/static/b73eddb438f370d3016325b693797c65/413c2/Anonymous.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'Kelly Li',
+      img: 'https://tse.ucsd.edu/static/b73eddb438f370d3016325b693797c65/413c2/Anonymous.jpg',
+      position: 'Designer'
+    },
+    {
+      name: 'Viren Abhyankar',
+      img: 'https://tse.ucsd.edu/static/870d5afcd364c917a1271531c338b4ee/252bd/VirenAbhyankar.jpg',
+      position: 'VP External'
+    }
+  ]
+];
+
+const amazingWinnersFA20DesignWorkshop = [
+  [
+    {
+      name: 'Dhanush Nanjunda Reddy',
+      img: 'https://tse.ucsd.edu/static/8badbac7202ec344093488c0b16c5d7a/97641/DhanushReddy.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'Nicolas La Polla',
+      img: 'https://tse.ucsd.edu/static/b4ef52426ab7700650ea32a42fe94bff/b408d/NickLaPolla.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'Nirmal Agnihotri',
+      img: 'https://tse.ucsd.edu/static/44edd4ff02e5aac2862a703246f3e0d8/c3133/NirmalAgnihotri.jpg',
+      position: 'Developer'
+    }
+  ],
+  [
+    {
+      name: 'Rohith Kasar',
+      img: 'https://tse.ucsd.edu/static/11f5f300153240d114c4aa1c7a35c740/252bd/RohithKasar.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'Thai Gillespie',
+      img: 'https://tse.ucsd.edu/static/b73eddb438f370d3016325b693797c65/413c2/Anonymous.jpg',
+      position: 'Developer'
+    },
+    {
+      name: 'Wesley Chen',
+      img: 'https://tse.ucsd.edu/static/be4c7ed3662f11e557a5558398f1ad14/222d7/WesleyChen.jpg',
+      position: 'President'
+    }
+  ]
+];
+
 const amazingWinnersFA20AllHands2 = [
   [
     {
@@ -14,7 +71,7 @@ const amazingWinnersFA20AllHands2 = [
       position: 'Project Manager'
     },
     {
-      name: 'Dhanush Nanjunda',
+      name: 'Dhanush Nanjunda Reddy',
       img: 'https://tse.ucsd.edu/static/8badbac7202ec344093488c0b16c5d7a/97641/DhanushReddy.jpg',
       position: 'Developer'
     },
@@ -87,6 +144,8 @@ export default ({
     return (
         <div className='body'>
             <Matrix/>
+            <Winners winners={amazingWinnersFA20SocialEvent} activity={"FA20 Trivia Winners"}/>
+            <Winners winners={amazingWinnersFA20DesignWorkshop} activity={"FA20 Design Violation Detection Winners"}/>
             <Winners winners={amazingWinnersFA20AllHands2} activity={"FA20 Many Truths One Lie Winners"}/>
             <Winners winners={amazingWinnersFA20AllHands1} activity={"FA20 Family Feud Winners"}/>
             <Winners winners={amazingWinnersSP20AllHands2} activity={"SP20 Codewords Winners"}/>


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 856673394
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

Resolves #32 and resolves #33 .

### Changes
What changes did you make?
- Added winners of design workshop and social event to the winners page.

### Testing
How did you confirm your changes worked? 
- ran the website locally, and confirmed the changes worked properly.

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

| Updated TSE Hall of Fame |
| --- |
| ![image](https://user-images.githubusercontent.com/35469114/100525846-7abd6080-3178-11eb-98ef-b408466c4350.png) |
