### PR TITLE
Add distribution app team to winners page for team photos

### DIFF
--- a/src/data/winners/WI21_Team_Photos.json
+++ b/src/data/winners/WI21_Team_Photos.json
@@ -1,0 +1,38 @@
+{
+  "activity": "WI21 Team Photo Winners (Distribution Web App)",
+  "ordering": 8,
+  "winners": [
+    {
+      "name": "Sara Blumin",
+      "position": "Project Manager"
+    },
+    {
+      "name": "Roger Ji",
+      "position": "Developer"
+    },
+    {
+      "name": "William Wu",
+      "position": "Developer"
+    },
+    {
+      "name": "Nicolas La Polla",
+      "position": "Developer"
+    },
+    {
+      "name": "Nirmal Agnihotri",
+      "position": "Developer"
+    },
+    {
+      "name": "Ryan Bui",
+      "position": "Developer"
+    },
+    {
+      "name": "Stephen Tan",
+      "position": "Developer"
+    },
+    {
+      "name": "Emmanuel Flores",
+      "position": "Developer"
+    }
+  ]
+}


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 856673394
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Added new winners item

### Testing
How did you confirm your changes worked? 
![image](https://user-images.githubusercontent.com/3221148/112890948-1d410e00-909d-11eb-9d6d-21335de4cf48.png)

