### PR TITLE
Add Viren & Ly as debate night winners

### DIFF
--- a/src/data/winners/SP21_Mentorship_Debate_Night.json
+++ b/src/data/winners/SP21_Mentorship_Debate_Night.json
@@ -1,0 +1,14 @@
+{
+  "activity": "SP21 Mentorship Debate Night",
+  "ordering": 10,
+  "winners": [
+    {
+      "name": "Viren Abhyankar",
+      "position": "VP External"
+    },
+    {
+      "name": "Ly Nguyen",
+      "position": "Developer"
+    }
+  ]
+}


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 856673394
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Added file with Ly & Viren as debate night winners for the mentorship program.
