### PR TITLE
Add winner for generals.io tournament

### DIFF
--- a/src/data/winners/SP21_Social_Event.json
+++ b/src/data/winners/SP21_Social_Event.json
@@ -1,0 +1,10 @@
+{
+  "activity": "SP21 generals.io Tournament",
+  "ordering": 10.5,
+  "winners": [
+    {
+      "name": "David Hacker",
+      "position": "VP Technology"
+    }
+  ]
+}


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 856673394
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Add the illustrious winner of the SP21 generals.io tournament

### Testing
How did you confirm your changes worked? 
- Viewed the winners page locally

### Confirmation of Change 
Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

| Winners Page |
| --- |
| ![image](https://user-images.githubusercontent.com/19500553/121590903-bec5d380-c9ed-11eb-9754-11f594f95db8.png) |
