### PR TITLE
added upcoming events to hompage

### DIFF
--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -3,6 +3,8 @@ import { DateTime } from "luxon";
 
 import ArrowLink from "./ArrowLink";
 
+import "./Events.css";
+
 /**
  * Display information about an event.
  * @param props
@@ -14,16 +16,24 @@ import ArrowLink from "./ArrowLink";
  */
 export default function Event({ title, description, location, startTime, url }) {
   return (
-    <div>
-      <p>
-        <strong>{title}</strong>
-      </p>
-      <p>{description}</p>
-      <p>Where: {location}</p>
-      <p>When: {startTime.toLocaleString(DateTime.DATETIME_FULL)}</p>
-      <p>
-        <ArrowLink to={url}>Learn More</ArrowLink>
-      </p>
+    <div className="col-md-6 my-3 d-flex align-items-stretch justify-content-around">
+      <div className="event-card card p-4">
+        <h2 className="card-title mb-4 ">
+          <strong>{title}</strong>
+        </h2>
+        <p>{description}</p>
+        <p>
+          {" "}
+          <strong>Where:</strong> {location}
+        </p>
+        <p>
+          {" "}
+          <strong>When:</strong> {startTime.toLocaleString(DateTime.DATETIME_FULL)}
+        </p>
+        <p>
+          <ArrowLink to={url}>Learn More</ArrowLink>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/Events.css
+++ b/src/components/Events.css
@@ -1,0 +1,7 @@
+.event-card {
+  max-width: 800px;
+}
+
+.empty-event {
+  min-height: 300px;
+}

--- a/src/components/UpcomingEvents.js
+++ b/src/components/UpcomingEvents.js
@@ -1,0 +1,54 @@
+import React from "react";
+
+import Event from "./Event";
+import { allEvents } from "../data";
+
+import { sortByEarliest, getUpcomingEvents } from "../util/events";
+
+const getNRecentEvents = (numToShow = -1) => {
+  // TODO: line below will get all upcoming events, but since data currently is all past event, we do no need this
+  // let upcomingEvents = getUpcomingEvents(allEvents);
+
+  // TODO: delete this line and uncomment top line when data/events.js is updated
+  const upcomingEvents = allEvents;
+  const sortedUpcomingEvents = sortByEarliest(upcomingEvents);
+
+  return numToShow < 0 ? sortedUpcomingEvents : sortedUpcomingEvents.slice(0, numToShow);
+};
+
+const emptyEvent = {
+  title: "No Upcoming Events",
+  description:
+    "There are currently no events planned for the forseeable future, but make came back later or follow us on our socials to keep up to date",
+};
+
+/**
+ * Tabbed interface showing members, alumni, and clients.
+ * @param props
+ */
+export default function UpcomingEvents(props) {
+  // gets all events if number of events not specified
+  const upcomingEvents =
+    "numToShow" in props ? getNRecentEvents(props["numToShow"]) : getNRecentEvents();
+
+  return (
+    <div className="row m-5 text-dark">
+      {upcomingEvents.length === 0 ? (
+        <div className="col-md-6 my-3 d-flex align-items-stretch justify-content-around">
+          <div className="empty-event event-card card p-4">
+            <h2 className="card-title mb-4 ">
+              <strong>{emptyEvent.title}</strong>
+            </h2>
+            <p>{emptyEvent.description}</p>
+          </div>
+        </div>
+      ) : (
+        ""
+      )}
+
+      {upcomingEvents.map((event) => (
+        <Event {...event} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -3,5 +3,8 @@ title: Home
 ---
 
 import RecruitmentCard from "../components/RecruitmentCard";
+import UpcomingEvents from "../components/UpcomingEvents";
 
 <RecruitmentCard />
+
+<UpcomingEvents />

--- a/src/util/events.js
+++ b/src/util/events.js
@@ -1,0 +1,30 @@
+/**
+ * Event sorting and filtering functions
+ */
+
+export function sortByEarliest(events) {
+  return events.sort(compare);
+}
+
+export function getUpcomingEvents(events) {
+  // filter events that have already passed
+  const upcomingEvents = events.filter((event) => {
+    if (new Date(event.startTime) > new Date()) {
+      return true;
+    }
+  });
+
+  return upcomingEvents;
+}
+
+let compare = (a, b) => {
+  const aDate = new Date(a.startTime);
+  const bDate = new Date(b.startTime);
+  if (aDate < bDate) {
+    return -1;
+  }
+  if (aDate > bDate) {
+    return 1;
+  }
+  return 0;
+};


### PR DESCRIPTION
### Administrative Info

Monday Board ID: 1444537937
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes

Added upcoming events to homepage
If there are no events planned of the future, display a "no event" card


### Testing

tested with different number of events to display
changed dates of events to properly filter out events that have passed


### Confirmation of Change

Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

This is showing all the events including past events (currently I'm displaying all events, but I have line of code that will only display upcoming events, I just commented that out for now because data/event.js has no upcoming events)
![image](https://user-images.githubusercontent.com/55808666/126915816-372444cd-83e3-4047-a950-15bb59bb2943.png)

Have the ability to specify how many upcoming events we want to show
![image](https://user-images.githubusercontent.com/55808666/126915857-db7b13aa-9fb2-4f75-b050-9bfd1106f75f.png)

Here's what the upcoming events section would look like if we actually have events that haven't passed
![image](https://user-images.githubusercontent.com/55808666/126915912-38df2490-4dc2-44bb-b71a-f557eb6df8f5.png)

And here's what it would look like if we have no upcoming events 
![image](https://user-images.githubusercontent.com/55808666/126915925-7f54d49e-bcd5-468d-8acd-79c1831f3292.png)

***Right now the code will display all events, when data/event.js is updated, I specified in the code what line needs to be uncommented and what line needs to be deleted to start display upcoming future events***



