### PR TITLE
sorted members and alumnis

### DIFF
--- a/src/components/Profiles.js
+++ b/src/components/Profiles.js
@@ -3,14 +3,17 @@ import React from "react";
 import Profile from "./Profile";
 import { clients, currentMembers, alumni } from "../data";
 import { nameToFilename } from "../util/strings";
+import { sortMembersByRole, categorizeMembersIntoYears } from "../util/members";
 
 function getProfilesFromCategory(category) {
   switch (category) {
     case "members":
+      sortMembersByRole(currentMembers);
       return currentMembers;
 
     case "alumni":
-      return alumni;
+      const result = categorizeMembersIntoYears(alumni);
+      return result;
 
     case "clients":
       return clients;
@@ -32,6 +35,8 @@ function getSocialsFromClients(profile) {
   return { website: profile.website };
 }
 
+getProfilesFromCategory("alumni");
+
 /**
  * Tabbed interface showing members, alumni, and clients.
  * @param props
@@ -43,19 +48,54 @@ export default function Profiles(props /* { members, clients } */) {
   return (
     <div className={`tab-content text-light row  ${props.display ? "d-flex" : "d-none"}`}>
       {
-        // creates a profile for each member/client
-        getProfilesFromCategory(props.name).map((profile) => (
-          <Profile
-            imagePaths={[`${category}/${nameToFilename(profile.name)}`, `${category}/anonymous`]}
-            title={profile.name}
-            subtitles={
-              category === "clients"
-                ? getSubtitlesFromClients(profile)
-                : getSubtitlesFromMembers(profile)
-            }
-            socials={category === "clients" ? getSocialsFromClients(profile) : profile.socials}
-          />
-        ))
+        // creates a profile for alumni that is categorized into graduation year
+        props.name === "alumni"
+          ? Object.keys(getProfilesFromCategory(props.name))
+              .reverse()
+              .map((yearRange) => (
+                <div>
+                  <h2 className="px-5 pt-5 mt-3">Class of {yearRange}</h2>
+                  <div className="row">
+                    {
+                      // loops through each alumni in the year range
+                      getProfilesFromCategory(props.name)[yearRange].map((profile) => (
+                        <Profile
+                          imagePaths={[
+                            `${category}/${nameToFilename(profile.name)}`,
+                            `${category}/anonymous`,
+                          ]}
+                          title={profile.name}
+                          subtitles={
+                            category === "clients"
+                              ? getSubtitlesFromClients(profile)
+                              : getSubtitlesFromMembers(profile)
+                          }
+                          socials={
+                            category === "clients"
+                              ? getSocialsFromClients(profile)
+                              : profile.socials
+                          }
+                        />
+                      ))
+                    }
+                  </div>
+                </div>
+              ))
+          : getProfilesFromCategory(props.name).map((profile) => (
+              <Profile
+                imagePaths={[
+                  `${category}/${nameToFilename(profile.name)}`,
+                  `${category}/anonymous`,
+                ]}
+                title={profile.name}
+                subtitles={
+                  category === "clients"
+                    ? getSubtitlesFromClients(profile)
+                    : getSubtitlesFromMembers(profile)
+                }
+                socials={category === "clients" ? getSocialsFromClients(profile) : profile.socials}
+              />
+            ))
       }
     </div>
   );

--- a/src/util/members.js
+++ b/src/util/members.js
@@ -1,0 +1,66 @@
+/**
+ * Member manipulation functions
+ */
+const ROLE_ORDER = [
+  "President",
+  "VP Operations",
+  "VP External",
+  "VP Technology",
+  "VP Projects",
+  "Outreach Lead",
+  "Marketing Lead",
+  "Project Manager",
+  "UI/UX Designer",
+  "Developer",
+];
+
+export function sortMembersByRole(members) {
+  members.sort(compareByRole);
+}
+
+let compareByRole = (a, b) => {
+  const aRole = a.roles[a.roles.length - 1];
+  const bRole = b.roles[b.roles.length - 1];
+  const roleComparison = ROLE_ORDER.indexOf(aRole) - ROLE_ORDER.indexOf(bRole);
+  if (roleComparison < 0) {
+    return -1;
+  }
+  if (roleComparison > 0) {
+    return 1;
+  }
+  // same role; sort by alphabetical first name
+
+  const aName = a.name;
+  const bName = b.name;
+  if (aName < bName) {
+    return -1;
+  }
+  if (aName > bName) {
+    return 1;
+  }
+
+  return 0;
+};
+
+/**
+ * given a list of members (must have a graduation year field), group them into years
+ */
+export function categorizeMembersIntoYears(members) {
+  const result = {};
+
+  for (const member of members) {
+    const graduationYear = member.graduationYear;
+    if (graduationYear in result) {
+      result[graduationYear].push(member);
+    } else {
+      result[graduationYear] = [member];
+    }
+  }
+
+  // sort the categorized members
+  for (const keys in result) {
+    result[keys].sort(compareByRole);
+  }
+
+  return result;
+}

--- a/src/util/members.js
+++ b/src/util/members.js
@@ -7,6 +7,7 @@ const ROLE_ORDER = [
   "VP External",
   "VP Technology",
   "VP Projects",
+  "VP Design",
   "Outreach Lead",
   "Marketing Lead",
   "Project Manager",


### PR DESCRIPTION
### Administrative Info

Monday Board ID: 1444537937
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes

What changes did you make?

Sorted members and alumni by their roles, currently using the ordering of 
![image](https://user-images.githubusercontent.com/55808666/129469232-1d5d44ca-ed20-4a28-9bee-ac040f914035.png)


### Testing

How did you confirm your changes worked?

Added a developer role to the top of /data/members.json and check if developer correctly showed up at the bottom
Also checked if exec board was showing up at top

### Confirmation of Change

Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

Exec board shows up at top of list
![image](https://user-images.githubusercontent.com/55808666/129469136-992749c9-680e-44d1-88d5-d6e062f9b686.png)

Placed Zain at top of the list in data/members.json, but from above image, zain is not there because he is at the bottom (developer role)
![image](https://user-images.githubusercontent.com/55808666/129469153-44539d68-1a26-481b-80ab-f9d9d97507ef.png)

Alumni Page categorized into years and ordered by roles
![image](https://user-images.githubusercontent.com/55808666/129469203-6041fd18-96f3-4641-9c36-d8e5641f4acf.png)



