### PR TITLE
Added constraint to student app form that year is valid integer

### DIFF
--- a/src/components/StudentApplication.js
+++ b/src/components/StudentApplication.js
@@ -243,7 +243,10 @@ export default function StudentApplication() {
             <Form.Label>Starting Year</Form.Label>
             <Form.Control
               required
-              type="text"
+              type="number"
+              min="2000"
+              max="2099"
+              step="1"
               name="startingYear"
               onChange={handleChange}
               className="text-dark"
@@ -271,7 +274,10 @@ export default function StudentApplication() {
             <Form.Label>Graduation Year</Form.Label>
             <Form.Control
               required
-              type="text"
+              type="number"
+              min="2000"
+              max="2099"
+              step="1"
               name="graduationYear"
               onChange={handleChange}
               className="text-dark"


### PR DESCRIPTION
### Administrative Info

Monday Board ID: 1444537937
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes

What changes did you make?

- Made start and graduation year fields on student app require a valid integer value

### Testing

How did you confirm your changes worked?

- Tested with year fields as letters or invalid numbers

### Confirmation of Change

Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change.

- Submit student form with invalid number for year field and appropriate error message should be displayed
