### PR TITLE
Switch from president to TSE email + fix rendering bug

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           npm ci
           npm run lint-check
-          npm run build   
+          npm run build
   test_links:
     name: Test website links
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -5,7 +5,7 @@ on:
     branches: main
 
 jobs:
-  frontend:
+  lint_check:
     name: Lint, style, and build checks
     runs-on: ubuntu-latest
     steps:
@@ -15,5 +15,14 @@ jobs:
         run: |
           npm ci
           npm run lint-check
-          npm run build
+          npm run build   
+  test_links:
+    name: Test website links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - working-directory: .
+        run: |
+          npm ci
           npm run link-test

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -391,8 +391,7 @@ We are no longer accepting applications for this school year. If you are interes
                 <br />
                 <br />
                 You may apply to either TSE or the TEST program, not both. If you are unsure about
-                which is right for you, please email [${recruitment.presidentEmail}](mailto:$
-                {recruitment.presidentEmail}).
+                which is right for you, please email <a href='mailto:tse@ucsd.edu'>tse@ucsd.edu</a>.
               </p>
             ),
           },

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -391,7 +391,7 @@ We are no longer accepting applications for this school year. If you are interes
                 <br />
                 <br />
                 You may apply to either TSE or the TEST program, not both. If you are unsure about
-                which is right for you, please email <a href='mailto:tse@ucsd.edu'>tse@ucsd.edu</a>.
+                which is right for you, please email <a href="mailto:tse@ucsd.edu">tse@ucsd.edu</a>.
               </p>
             ),
           },

--- a/data/recruitment.ts
+++ b/data/recruitment.ts
@@ -2,7 +2,6 @@ const recruitment = {
   acceptingApplications: false,
   applicationUrl: "https://tritonse.github.io/TSE-Application-Form/",
   deadline: "Sunday, October 13th at 11:59PM PDT",
-  presidentEmail: "v6liu@ucsd.edu",
 } as const;
 
 export default recruitment;


### PR DESCRIPTION
Previously, in the TEST FAQs on the website, we told people to email the president if they had any questions about the program. However, I think it makes more sense to tell them to email tse@ucsd.edu because:
1. The president should be checking the TSE email anyway (I'm signed into it on my phone)
2. This way, we don't have to update the president's email every year
3. This way, VPs with access to the TSE email (e.g. VP Ops) can see and help respond to questions
4. There are like 5 other places on the website where we tell people to contact us at tse@ucsd.edu, I feel like it makes sense to be consistent

So I changed the contact info to just be the TSE email. I also fixed a bug where the email wasn't rendering correctly because it was still using Markdown instead of HTML (we recently migrated these sections from Markdown to HTML/JSX)

Before:
<img width="1585" height="251" alt="Screenshot from 2025-08-19 19-08-37" src="https://github.com/user-attachments/assets/a2222634-f1fd-48cb-a4bc-fed54c554ef5" />


After:
<img width="1585" height="251" alt="Screenshot from 2025-08-19 19-13-58" src="https://github.com/user-attachments/assets/ecf4a721-707a-41a1-aca8-15b0e8ffda51" />

